### PR TITLE
SassC 3.5 support

### DIFF
--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,0 +1,33 @@
+FROM alpine:3.8
+ARG LIBSASS_VERSION=3.5.5
+ARG SASSC_VERSION=3.5.0
+
+ENV SASS_LIBSASS_PATH "/usr/local/libsass"
+
+RUN apk add --no-cache libstdc++
+
+# Compile and install SassC, without dependency bulk
+RUN apk add --no-cache --virtual build-dependencies \
+		build-base \
+		ca-certificates \
+		openssl \
+		unzip \
+	&& update-ca-certificates \
+	&& mkdir -p /usr/local /data \
+	&& cd /usr/local \
+	&& wget -O libsass.zip "https://github.com/sass/libsass/archive/${LIBSASS_VERSION}.zip" \
+	&& wget -O sassc.zip "https://github.com/sass/sassc/archive/${SASSC_VERSION}.zip" \
+	&& unzip libsass.zip \
+	&& unzip sassc.zip \
+	&& mv "sassc-${SASSC_VERSION}" sassc \
+	&& mv "libsass-${LIBSASS_VERSION}" libsass \
+	&& cd "/usr/local/sassc" \
+	&& make \
+	&& ln -s /usr/local/sassc/bin/sassc /usr/local/bin/sassc \
+	&& rm -fr /usr/local/*.zip \
+	&& apk del build-dependencies
+
+# Run SassC by default
+ENTRYPOINT ["sassc"]
+VOLUME /data
+WORKDIR /data


### PR DESCRIPTION
Added support for SassC 3.5.0 using libsass 3.5.5.

Also updated the alpine image version, since I got some SSL errors when 3.5. Honestly don't know what the problem was, but simply using 3.8 fixed it.